### PR TITLE
fix(vector-store): index creation error handling + explicit connection disposal 

### DIFF
--- a/src/ai/vector.db.ts
+++ b/src/ai/vector.db.ts
@@ -71,7 +71,12 @@ export const VectorStore = async ({
 				PREFIX: prefix,
 			},
 		);
-	} catch (e) {}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		if (!message.toLowerCase().includes("index already exists")) {
+			throw new Error(`Failed to create Redis index "${indexName}": ${message}`);
+		}
+	}
 
 	const insert = async ({ id, vector, metadata = {} }: InsertOptions) => {
 		if (!Array.isArray(vector) || vector.length !== vectorDimension) {
@@ -105,8 +110,13 @@ export const VectorStore = async ({
 		return res as QueryResult;
 	};
 
+	const close = async () => {
+		return await client.quit();
+	};
+
 	return {
 		insert,
 		query,
+		close,
 	};
 };

--- a/tests/integration/VectorStore.integration.test.ts
+++ b/tests/integration/VectorStore.integration.test.ts
@@ -131,6 +131,29 @@ describe('VectorStore integration - tag filtering', () => {
 });
 
 describe('VectorStore integration - error handling', () => {
+	it('does not fail when creating an already existing index', async () => {
+		const firstStore = await VectorStore({
+			indexName: TEST_INDEX,
+			prefix: TEST_PREFIX,
+			vectorDim: DIM,
+			configService,
+		});
+
+		const secondStorePromise = VectorStore({
+			indexName: TEST_INDEX,
+			prefix: TEST_PREFIX,
+			vectorDim: DIM,
+			configService,
+		});
+
+		await expect(secondStorePromise).resolves.toBeDefined();
+
+		const vector = randomVector();
+		await firstStore.insert({ id: 'doc-on-existing-index', vector });
+		const result = await firstStore.query({ vector, k: 1 });
+		expect(result.total).toBe(1);
+	});
+
   it('throws on insert with wrong vector dimension', async () => {
     const store = await VectorStore({
       indexName: TEST_INDEX,

--- a/tests/unit/VectorStore.test.ts
+++ b/tests/unit/VectorStore.test.ts
@@ -5,10 +5,12 @@ const mockHSet = vi.fn().mockResolvedValue(1);
 const mockFtSearch = vi.fn().mockResolvedValue({ total: 0, documents: [] });
 const mockFtCreate = vi.fn().mockResolvedValue('OK');
 const mockConnect = vi.fn().mockResolvedValue(undefined);
+const mockQuit = vi.fn().mockResolvedValue('OK');
 
 vi.mock('redis', () => ({
   createClient: vi.fn(() => ({
     connect: mockConnect,
+    quit: mockQuit,
     hSet: mockHSet,
     ft: {
       create: mockFtCreate,
@@ -72,6 +74,27 @@ describe('VectorStore - initialization', () => {
       }),
     ).resolves.toBeDefined();
   });
+
+	it('does not fail when Redis reports index already exists', async () => {
+		mockFtCreate.mockRejectedValueOnce(new Error('Index already exists'));
+
+		await expect(makeStore()).resolves.toBeDefined();
+	});
+
+	it('rethrows unexpected index creation errors with context', async () => {
+		mockFtCreate.mockRejectedValueOnce(new Error('permission denied'));
+
+		await expect(makeStore()).rejects.toThrow(
+			'Failed to create Redis index "test_index": permission denied',
+		);
+	});
+
+	it('closes the Redis client via close()', async () => {
+		const store = await makeStore();
+
+		await expect(store.close()).resolves.toBe('OK');
+		expect(mockQuit).toHaveBeenCalledOnce();
+	});
 });
 
 describe('VectorStore - insert', () => {


### PR DESCRIPTION
## Summary
This PR aims to improve Vector Store error handling and lifecycle.

In addition to the original test coverage effort, it now:
1. Replaces the silent `ft.create` catch with explicit, safe error handling.
2. Keeps startup idempotent by tolerating only `"index already exists"` errors.
3. Adds a `close()` API to dispose Redis connections cleanly via `client.quit()`.
4. Adds tests for both new behaviors (unit + integration).

## Context
The previous implementation swallowed all Redis index-creation failures, which could hide real operational issues (permissions, malformed schema, connectivity), and it opened Redis connections without exposing a cleanup path.

## What Changed

### 1) VectorStore initialization error handling
- Behavior before:
  - `catch (e) {}` silently ignored *all* `ft.create` failures.
- Behavior now:
  - Extracts error message.
  - Ignores only `"index already exists"` (idempotent startup).
  - Throws contextualized error for any other failure:
    - `Failed to create Redis index "<indexName>": <message>`

### 2) Added explicit close() method
- New API:
  - `close()`:  calls and returns `client.quit()`.

### 3) Unit tests expanded for new behavior
- Added tests:
  - `does not fail when Redis reports index already exists`
  - `rethrows unexpected index creation errors with context`
  - `closes the Redis client via close()`
- Mock updates:
  - Added mocked `quit` method in Redis client mock

### 4) Integration test expanded for idempotent initialization
- Added test:
  - `does not fail when creating an already existing index`
- Validates:
  - Re-initializing the same index succeeds and remains operational.

## Backward Compatibility
- Non-breaking for current callers of `insert`/`query`
- Adds new optional capability close for cleanup.